### PR TITLE
Allow alternate ACME URLs

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -76,10 +76,8 @@ func watchHostsChanges(filename string, fn func()) error {
 	watcher.Add(filename)
 
 	for {
-		select {
-		case <-watcher.Events:
-			fn()
-		}
+		<-watcher.Events
+		fn()
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
 )
 
@@ -13,6 +14,10 @@ func main() {
 	e.HideBanner = true
 	e.AutoTLSManager.HostPolicy = autocert.HostWhitelist(getAvailableHosts()...)
 	e.AutoTLSManager.Cache = autocert.DirCache(*flagAutocertCacheDir)
+	e.AutoTLSManager.Client = &acme.Client{
+		DirectoryURL: *flagACMEDirectory,
+		UserAgent:    "https://github.com/alash3al/httpsify",
+	}
 
 	e.Use(middleware.HTTPSRedirect())
 	e.Use(middleware.Logger())

--- a/vars.go
+++ b/vars.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 
 	"github.com/mitchellh/go-homedir"
+	"golang.org/x/crypto/acme/autocert"
 )
 
 var (
@@ -18,5 +19,6 @@ var (
 	flagHTTPAddr         = flag.String("http", ":80", "the port to listen for http requests on, it is recommended to leave it as is")
 	flagAutocertCacheDir = flag.String("certs", path.Join(homeDir, ".httpsify/certs"), "the certs directory")
 	flagHostsFile        = flag.String("hosts", path.Join(homeDir, ".httpsify/hosts.json"), "the file containing hosts mappings to upstreams")
+	flagACMEDirectory    = flag.String("acme-directory", autocert.DefaultACMEDirectory, "the server to request certificates from")
 	flagSendXSecuredBy   = flag.Bool("x-secured-by", true, "whether to enable x-secured-by header or not")
 )


### PR DESCRIPTION
This allows setting the ACME directory URL via a command line flag. This enables users to use the [Let's Encrypt staging environment](https://letsencrypt.org/docs/staging-environment/) or [other CAs](https://zerossl.com/letsencrypt-alternative/).